### PR TITLE
1.1.0-0: Allow the user to modify the priority of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ luarocks pack kong-plugin-bodyrequest-auth 1.0.0
 # Set propper version
 ```
 
+## Priority
+By default, the priority of the plugin is 900. You can change it using an environment variable:
+```
+BODYREQUEST_AUTH_PRIORITY=1000
+```
+
 ## Test local
 
 ### Start pongo

--- a/kong-plugin-bodyrequest-auth-1.1.0-0.rockspec
+++ b/kong-plugin-bodyrequest-auth-1.1.0-0.rockspec
@@ -1,7 +1,7 @@
 local plugin_name = "bodyrequest-auth"
 local package_name = "kong-plugin-" .. plugin_name
-local package_version = "1.0.0"
-local rockspec_revision = "1"
+local package_version = "1.1.0"
+local rockspec_revision = "0"
 
 local github_account_name = "OptareSolutions"
 local github_repo_name = "kong-bodyrequest-auth"

--- a/kong/plugins/bodyrequest-auth/handler.lua
+++ b/kong/plugins/bodyrequest-auth/handler.lua
@@ -4,6 +4,18 @@ local cjson = require "cjson"
 local kong = kong
 local ExternalAuthHandler = BasePlugin:extend()
 
+local priority_env_var = "BODYREQUEST_AUTH_PRIORITY"
+local priority
+if os.getenv(priority_env_var) then
+    priority = tonumber(os.getenv(priority_env_var))
+else
+    priority = 900
+end
+kong.log.debug('BODYREQUEST_AUTH_PRIORITY: ' .. priority)
+
+ExternalAuthHandler.PRIORITY = priority
+ExternalAuthHandler.VERSION = "1.1.0"
+
 function ExternalAuthHandler:new()
   ExternalAuthHandler.super.new(self, "bodyrequest-auth")
 end
@@ -59,8 +71,5 @@ function ExternalAuthHandler:access(conf)
 
   kong.service.request.set_header(conf.header_request, "Bearer " .. token[conf.json_token_key])
 end
-
-ExternalAuthHandler.PRIORITY = 900
-ExternalAuthHandler.VERSION = "1.0.0"
 
 return ExternalAuthHandler


### PR DESCRIPTION
Add envvar `BODYREQUEST_AUTH_PRIORITY` so the user can modify the priority of the plugin

Also, modify the version of the plugin and the .rockspec filename to 1.1.0-0