### PR TITLE
Agregar soporte para el almacenamiento de los tokens en cache

### DIFF
--- a/kong-plugin-bodyrequest-auth-2.0.0-0.rockspec
+++ b/kong-plugin-bodyrequest-auth-2.0.0-0.rockspec
@@ -1,7 +1,7 @@
 local plugin_name = "bodyrequest-auth"
 local package_name = "kong-plugin-" .. plugin_name
 local package_version = "2.0.0"
-local rockspec_revision = "1"
+local rockspec_revision = "0"
 
 local github_account_name = "OptareSolutions"
 local github_repo_name = "kong-bodyrequest-auth"

--- a/kong-plugin-bodyrequest-auth-2.0.0-1.rockspec
+++ b/kong-plugin-bodyrequest-auth-2.0.0-1.rockspec
@@ -1,6 +1,6 @@
 local plugin_name = "bodyrequest-auth"
 local package_name = "kong-plugin-" .. plugin_name
-local package_version = "1.2.0"
+local package_version = "2.0.0"
 local rockspec_revision = "1"
 
 local github_account_name = "OptareSolutions"

--- a/kong/plugins/bodyrequest-auth/handler.lua
+++ b/kong/plugins/bodyrequest-auth/handler.lua
@@ -5,6 +5,8 @@ local BodyRequestAuthHandler = {
   VERSION = "1.2.0"
 }
 
+local CACHE_TOKEN_KEY = "oauth_token"
+
 local priority_env_var = "BODYREQUEST_AUTH_PRIORITY"
 local priority
 if os.getenv(priority_env_var) then
@@ -17,6 +19,93 @@ kong.log.debug('BODYREQUEST_AUTH_PRIORITY: ' .. priority)
 BodyRequestAuthHandler.PRIORITY = priority
 
 function BodyRequestAuthHandler:access(conf)
+
+  local tokenInfo = nil
+
+  -- Get token with cache
+  if conf.cache_enabled then
+    if conf.log_enabled then
+      kong.log.info("Cache enabled")
+    end
+    tokenInfo = get_cache_token(conf)
+    if not tokenInfo then
+      if conf.log_enabled then
+        kong.log.info("No token in cache. Call OAuth provider to update it")
+      end
+      tokenInfo = kong.cache:get(CACHE_TOKEN_KEY, nil, get_oauth_token, conf)
+    end
+  -- Get token without cache
+  else
+    tokenInfo = get_oauth_token(conf)
+  end
+
+  -- Final validation and set header
+  if not tokenInfo then
+    return kong.response.exit(401, {message="Invalid authentication credentials"})
+  end
+
+  if conf.log_enabled then
+    kong.log.info("Login success.")
+    kong.log.debug("Token: " .. cjson.encode(tokenInfo))
+  end
+
+  kong.service.request.set_header(conf.header_request, "Bearer " .. tokenInfo.token)
+end
+
+
+-------------
+-- FUNCTIONS
+-------------
+
+-- Get token from cache
+function get_cache_token(conf)
+  local token = kong.cache:get(CACHE_TOKEN_KEY)
+  -- If value in cache is nil we must invalidate it
+  if not token or not token.expiration then
+    kong.cache:invalidate(CACHE_TOKEN_KEY)
+    return nil
+  end
+
+  local timeToRefeshToken = token.expiration + conf.expiration_margin
+
+  if token.expiration and (token.expiration < os.time()) and (timeToRefeshToken > os.time())
+  and conf.refresh_url and conf.refresh_path then
+      if conf.log_enabled then
+        kong.log.debug("Get new token using refresh token ", token.expiration)
+      end
+      local refreshToken = token.refreshToken
+      kong.cache:invalidate(CACHE_TOKEN_KEY)
+
+      token = kong.cache:get(CACHE_TOKEN_KEY, nil, get_refresh_oauth_token, conf, refreshToken)
+      kong.log.debug("New expiration time is ", token.expiration)
+  end
+
+  if token.expiration and (token.expiration < os.time()) then
+    -- Token is expired invalidate it
+    if conf.log_enabled then
+      kong.log.debug("Invalidate expired token: " .. cjson.encode(token))
+    end
+    kong.cache:invalidate(CACHE_TOKEN_KEY)
+    return nil
+  end
+
+  return token
+end
+
+-- Get token from OAuth provider
+function get_oauth_token(conf)
+  local res, err = perform_login(conf)
+
+  local error_message = validate_login(res, err, conf)
+  if error_message then
+    return nil;
+  end
+
+  return get_token_from_response(res, conf)
+end
+
+-- Login
+function perform_login(conf)
   local client = http.new()
   client:set_timeouts(conf.connect_timeout, conf.send_timeout, conf.read_timeout)
 
@@ -27,45 +116,106 @@ function BodyRequestAuthHandler:access(conf)
     kong.log.warn("Method: ", conf.method)
   end
 
-  -- Login
-  local res, err = client:request_uri(conf.url, {
-    method = conf.method,
-    path = conf.path,
-    body = cjson.encode({
-      [conf.username_key] = conf.username_value,
-      [conf.password_key] = conf.password_value
-    })
-  })
+  return client:request_uri(
+    conf.url,
+    {
+      method = conf.method,
+      path = conf.path,
+      body = cjson.encode({
+        [conf.username_key] = conf.username_value,
+        [conf.password_key] = conf.password_value
+      })
+    }
+  )
+end
 
-  -- Validate login response
+-- Validate login response
+function validate_login(res, err, conf)
   if not res then
     if conf.log_enabled then
-      kong.log.warn("No response. Error: ", err)
+      kong.log.err("No response. Error: ", err)
     end
-    return kong.response.exit(401, {
-      message = "Invalid authentication credentials"
-    })
-    -- return kong.response.exit(401, {message=err})
+    return "No response from OAuth provider"
   end
 
   if res.status ~= 200 then
     if conf.log_enabled then
-      kong.log.warn("Got error status ", res.status, res.body)
+      kong.log.err("Got error status ", res.status, res.body)
     end
+    return "Invalid authentication credentials"
+  end
+end
 
-    return kong.response.exit(401, {
-      message = "Invalid authentication credentials"
-    })
-    -- return kong.response.exit(401, {message=res.body})
+-- Extract token
+function get_token_from_response(res, conf)
+  local responseBody = cjson.decode(res.body)
+
+  local expirationValue = nil
+  local ttlValue = nil
+  local refreshTokenValue = nil
+  if responseBody[conf.json_expires_in_key] then
+    expirationValue = os.time() + responseBody[conf.json_expires_in_key] - conf.expiration_margin - conf.time_out_test
+    ttlValue = responseBody[conf.json_expires_in_key]
+  elseif conf.manual_time_out and conf.manual_time_out > 0 then
+      expirationValue = os.time() + conf.manual_time_out
+      ttlValue = conf.manual_time_out
+  else
+    ttlValue = 0
   end
 
-  -- Retrieve login token
-  local token = cjson.decode(res.body)
+  if responseBody[conf.json_refresh_token_response_key] then
+      refreshTokenValue = responseBody[conf.json_refresh_token_response_key]
+  else
+      refreshTokenValue = ""
+  end
+
   if conf.log_enabled then
-    kong.log.warn("Login success. Token: " .. token[conf.json_token_key])
+    kong.log.debug("Current time: ", os.time())
+    kong.log.debug("Expiration time: ", expirationValue)
   end
 
-  kong.service.request.set_header(conf.header_request, "Bearer " .. token[conf.json_token_key])
+  return {
+    token = responseBody[conf.json_token_key],
+    ttl = ttlValue,
+    refreshToken = refreshTokenValue,
+    expiration = expirationValue
+  };
+end
+
+-- Get new token using refresh token from OAuth provider
+function get_refresh_oauth_token(conf, refreshToken)
+  local res, err = perform_login_with_refresh_token(conf, refreshToken)
+
+  local error_message = validate_login(res, err, conf)
+  if error_message then
+    return nil;
+  end
+
+  return get_token_from_response(res, conf)
+end
+
+-- Login
+function perform_login_with_refresh_token(conf, refreshToken)
+  local client = http.new()
+  client:set_timeouts(conf.connect_timeout, conf.send_timeout, conf.read_timeout)
+
+  if conf.log_enabled then
+    kong.log.warn("Login via body request with refresh token")
+    kong.log.warn("Url:    ", conf.refresh_url)
+    kong.log.warn("Path:   ", conf.refresh_path)
+    kong.log.warn("Method: ", conf.refresh_method)
+  end
+
+  return client:request_uri(
+    conf.refresh_url,
+    {
+      method = conf.refresh_method,
+      path = conf.refresh_path,
+      body = cjson.encode({
+        [conf.json_refresh_token_request_key] = refreshToken
+      })
+    }
+  )
 end
 
 return BodyRequestAuthHandler

--- a/kong/plugins/bodyrequest-auth/handler.lua
+++ b/kong/plugins/bodyrequest-auth/handler.lua
@@ -2,7 +2,7 @@ local http = require "resty.http"
 local cjson = require "cjson"
 local kong = kong
 local BodyRequestAuthHandler = {
-  VERSION = "1.3.0"
+  VERSION = "2.0.0"
 }
 
 local CACHE_TOKEN_KEY = "body_request_plugin_token"
@@ -138,11 +138,11 @@ function get_token_from_response(res, conf)
   local ttlValue = nil
   local refreshTokenValue = nil
   if responseBody[conf.json_expires_in_key] then
-    expirationValue = os.time() + responseBody[conf.json_expires_in_key] - conf.expiration_margin - conf.time_out_test
+    expirationValue = os.time() + responseBody[conf.json_expires_in_key] - conf.expiration_margin - conf.timeout_test
     ttlValue = responseBody[conf.json_expires_in_key]
-  elseif conf.manual_time_out and conf.manual_time_out > 0 then
-      expirationValue = os.time() + conf.manual_time_out
-      ttlValue = conf.manual_time_out
+  elseif conf.manual_timeout and conf.manual_timeout > 0 then
+      expirationValue = os.time() + conf.manual_timeout
+      ttlValue = conf.manual_timeout
   else
     ttlValue = 0
   end

--- a/kong/plugins/bodyrequest-auth/handler.lua
+++ b/kong/plugins/bodyrequest-auth/handler.lua
@@ -27,7 +27,7 @@ function BodyRequestAuthHandler:access(conf)
     kong.log.info("Cache enabled")
     tokenInfo = get_cache_token(conf)
     if not tokenInfo then
-      kong.log.info("No token in cache. Call token provider to update it")
+      kong.log.debug("No token in cache. Call token provider to update it")
       tokenInfo = kong.cache:get(CACHE_TOKEN_KEY, nil, get_token, conf)
     end
   -- Get token without cache

--- a/kong/plugins/bodyrequest-auth/schema.lua
+++ b/kong/plugins/bodyrequest-auth/schema.lua
@@ -82,12 +82,6 @@ return {
             }
           },
           {
-            log_enabled = {
-              default = false,
-              type = "boolean"
-            }
-          },
-          {
             refresh_url = typedefs.url({
               required = false
             })

--- a/kong/plugins/bodyrequest-auth/schema.lua
+++ b/kong/plugins/bodyrequest-auth/schema.lua
@@ -86,6 +86,65 @@ return {
               default = false,
               type = "boolean"
             }
+          },
+          {
+            refresh_url = typedefs.url({
+              required = false
+            })
+          },
+          {
+            refresh_path = {
+              required = false,
+              type = "string"
+            }
+          },
+          {
+            refresh_method = {
+              default = "GET",
+              type = "string"
+            }
+          },
+          {
+            json_refresh_token_response_key = {
+              default = "refreshToken",
+              type = "string"
+            }
+          },
+          {
+            json_refresh_token_request_key = {
+              default = "token",
+              type = "string"
+            }
+          },
+          {
+            json_expires_in_key = {
+              default = "expiresIn",
+              type = "string"
+            }
+          },
+          {
+            cache_enabled = {
+              default = false,
+              type = "boolean"
+            }
+          },
+          {
+            expiration_margin = {
+              default = 5,
+              type = "number"
+            }
+          },
+          {
+            manual_time_out = {
+              default = 0,
+              type = "number"
+            }
+          },
+            {
+            time_out_test = {
+              default = 0,
+              type = "number"
+            }
           }
         }
       }

--- a/kong/plugins/bodyrequest-auth/schema.lua
+++ b/kong/plugins/bodyrequest-auth/schema.lua
@@ -129,13 +129,13 @@ return {
             }
           },
           {
-            manual_time_out = {
+            manual_timeout = {
               default = 0,
               type = "number"
             }
           },
             {
-            time_out_test = {
+            timeout_test = {
               default = 0,
               type = "number"
             }


### PR DESCRIPTION
Se agrega la posibilidad de almacenar los tokens obtenidos en cache para así reducir la cantidad de llamadas realizadas.
También se agrega la posibilidad de obtener un nuevo token por medio de un endpoint de refreshToken (en caso de existir).
Así mismo, también existe la posibilidad de aunque en la respuesta no venga indicado un tiempo de expiración del token, poder fijar uno de forma manual.