### PR TITLE
Add support to save auth tokens in cache

### DIFF
--- a/kong/plugins/bodyrequest-auth/handler.lua
+++ b/kong/plugins/bodyrequest-auth/handler.lua
@@ -22,6 +22,9 @@ function BodyRequestAuthHandler:access(conf)
 
   local tokenInfo = nil
 
+  if conf.cache_key
+    CACHE_TOKEN_KEY = CACHE_TOKEN_KEY .. conf.cache_key
+
   -- Get token with cache
   if conf.cache_enabled then
     kong.log.info("Cache enabled")

--- a/kong/plugins/bodyrequest-auth/schema.lua
+++ b/kong/plugins/bodyrequest-auth/schema.lua
@@ -123,6 +123,12 @@ return {
             }
           },
           {
+            cache_key = {
+              required = false,
+              type = "string"
+            }
+          },
+          {
             expiration_margin = {
               default = 5,
               type = "number"


### PR DESCRIPTION
Se agrega un parámetro en la confi que permite setear el nombre de la clave con la que se almacenará el token en caché.