### PR TITLE
Add support to save auth tokens in cache

### DIFF
--- a/kong/plugins/bodyrequest-auth/handler.lua
+++ b/kong/plugins/bodyrequest-auth/handler.lua
@@ -24,6 +24,7 @@ function BodyRequestAuthHandler:access(conf)
 
   if conf.cache_key then
     CACHE_TOKEN_KEY = CACHE_TOKEN_KEY .. conf.cache_key
+  end
 
   -- Get token with cache
   if conf.cache_enabled then


### PR DESCRIPTION
Se agrega un nuevo parámetro a la configuración para permitir especificar la key con la que se va a almacenar en cache el token.