### PR TITLE
Add support to save auth tokens in cache

### DIFF
--- a/kong/plugins/bodyrequest-auth/handler.lua
+++ b/kong/plugins/bodyrequest-auth/handler.lua
@@ -22,7 +22,7 @@ function BodyRequestAuthHandler:access(conf)
 
   local tokenInfo = nil
 
-  if conf.cache_key then
+  if conf.cache_key and CACHE_TOKEN_KEY == "body_request_plugin_token" then
     CACHE_TOKEN_KEY = CACHE_TOKEN_KEY .. conf.cache_key
   end
 


### PR DESCRIPTION
Se agrega un nuevo parámetro a la configuración para permitir especificar la key con la que se va a almacenar en cache el token.
