### PR TITLE
Add support to save auth tokens in cache

### DIFF
--- a/kong/plugins/bodyrequest-auth/handler.lua
+++ b/kong/plugins/bodyrequest-auth/handler.lua
@@ -5,8 +5,6 @@ local BodyRequestAuthHandler = {
   VERSION = "2.0.0"
 }
 
-local CACHE_TOKEN_KEY = "body_request_plugin_token"
-
 local priority_env_var = "BODYREQUEST_AUTH_PRIORITY"
 local priority
 if os.getenv(priority_env_var) then
@@ -22,17 +20,13 @@ function BodyRequestAuthHandler:access(conf)
 
   local tokenInfo = nil
 
-  if conf.cache_key and CACHE_TOKEN_KEY == "body_request_plugin_token" then
-    CACHE_TOKEN_KEY = CACHE_TOKEN_KEY .. conf.cache_key
-  end
-
   -- Get token with cache
   if conf.cache_enabled then
     kong.log.info("Cache enabled")
     tokenInfo = get_cache_token(conf)
     if not tokenInfo then
       kong.log.debug("No token in cache. Call token provider to update it")
-      tokenInfo = kong.cache:get(CACHE_TOKEN_KEY, nil, get_token, conf)
+      tokenInfo = kong.cache:get(conf.cache_key, nil, get_token, conf)
     end
   -- Get token without cache
   else
@@ -58,10 +52,10 @@ end
 
 -- Get token from cache
 function get_cache_token(conf)
-  local token = kong.cache:get(CACHE_TOKEN_KEY)
+  local token = kong.cache:get(conf.cache_key)
   -- If value in cache is nil we must invalidate it
   if not token or not token.expiration then
-    kong.cache:invalidate(CACHE_TOKEN_KEY)
+    kong.cache:invalidate(conf.cache_key)
     return nil
   end
 
@@ -71,15 +65,15 @@ function get_cache_token(conf)
   and conf.refresh_url and conf.refresh_path then
       kong.log.debug("Get new token using refresh token ", token.expiration)
       local refreshToken = token.refreshToken
-      kong.cache:invalidate(CACHE_TOKEN_KEY)
+      kong.cache:invalidate(conf.cache_key)
 
-      token = kong.cache:get(CACHE_TOKEN_KEY, nil, get_refresh_token, conf, refreshToken)
+      token = kong.cache:get(conf.cache_key, nil, get_refresh_token, conf, refreshToken)
   end
 
   if (token.expiration < os.time()) then
     -- Token is expired invalidate it
     kong.log.debug("Invalidate expired token: " .. cjson.encode(token))
-    kong.cache:invalidate(CACHE_TOKEN_KEY)
+    kong.cache:invalidate(conf.cache_key)
     return nil
   end
 

--- a/kong/plugins/bodyrequest-auth/schema.lua
+++ b/kong/plugins/bodyrequest-auth/schema.lua
@@ -124,7 +124,7 @@ return {
           },
           {
             cache_key = {
-              required = false,
+              default = "body_request_plugin_token",
               type = "string"
             }
           },


### PR DESCRIPTION
Se añade una característica a la configuración que permite especificar el nombre de la clave con la que se va a almacenar el token en caché.